### PR TITLE
(WIP,Do Not Merge)Exploration/UndeliverableToKafka

### DIFF
--- a/AdminAPI.md
+++ b/AdminAPI.md
@@ -27,7 +27,7 @@ The combination of an OpenAPI client and webhook processor is referred to as an 
 
 When ACA-Py is started with the `--webhook-url {URL}` command line parameter, state-management records are sent to the provided URL via POST requests whenever a record is created or its `state` property is updated.
 
-When a webhook is dispatched, the record `topic` is appended as a path component to the URL, for example: `https://webhook.host.example` becomes `https://webhook.host.example/connections` when a connection record is updated. A POST request is made to the resulting URL with the body of the request comprised by a serialized JSON object. The full set of properties of the current set of webhook payloads are listed below. Note that empty (null-value) properties are omitted.
+When a webhook is dispatched, the record `topic` is appended as a path component to the URL, for example: `https://webhook.host.example` becomes `https://webhook.host.example/topic/connections` when a connection record is updated. A POST request is made to the resulting URL with the body of the request comprised by a serialized JSON object. The full set of properties of the current set of webhook payloads are listed below. Note that empty (null-value) properties are omitted.
 
 #### Pairwise Connection Record Updated (`/connections`)
 

--- a/aries_cloudagent/commands/start.py
+++ b/aries_cloudagent/commands/start.py
@@ -104,5 +104,10 @@ def run_loop(startup: Coroutine, shutdown: Coroutine):
         loop.run_until_complete(done())
 
 
-if __name__ == "__main__":
-    execute()
+def main():
+    """Execute the main line."""
+    if __name__ == "__main__":
+        execute()
+
+
+main()

--- a/aries_cloudagent/commands/tests/test_start.py
+++ b/aries_cloudagent/commands/tests/test_start.py
@@ -2,26 +2,39 @@ from asynctest import TestCase as AsyncTestCase
 from asynctest import mock as async_mock
 
 from ...config.error import ArgsParseError
-from .. import start as command
+from .. import start as test_module
 
 
 class TestStart(AsyncTestCase):
     def test_bad_args(self):
         with self.assertRaises(ArgsParseError):
-            command.execute([])
+            test_module.execute([])
 
         with self.assertRaises(SystemExit):
-            command.execute(["bad"])
+            test_module.execute(["bad"])
+
+    async def test_start_shutdown_app(self):
+        mock_conductor = async_mock.MagicMock(
+            setup=async_mock.CoroutineMock(),
+            start=async_mock.CoroutineMock(),
+            stop=async_mock.CoroutineMock(),
+        )
+        await test_module.start_app(mock_conductor)
+        await test_module.shutdown_app(mock_conductor)
 
     def test_exec_start(self):
         with async_mock.patch.object(
-            command, "start_app", autospec=True
+            test_module, "start_app", autospec=True
         ) as start_app, async_mock.patch.object(
-            command, "run_loop"
+            test_module, "run_loop"
         ) as run_loop, async_mock.patch.object(
-            command, "shutdown_app", autospec=True
-        ) as shutdown_app:
-            command.execute(
+            test_module, "shutdown_app", autospec=True
+        ) as shutdown_app, async_mock.patch.object(
+            test_module, "uvloop", async_mock.MagicMock()
+        ) as mock_uvloop:
+            test_module.os.environ["WEBHOOK_URL"] = "http://localhost"
+            mock_uvloop.install = async_mock.MagicMock()
+            test_module.execute(
                 [
                     "-it",
                     "http",
@@ -36,9 +49,9 @@ class TestStart(AsyncTestCase):
                 ]
             )
             start_app.assert_called_once()
-            assert isinstance(start_app.call_args[0][0], command.Conductor)
+            assert isinstance(start_app.call_args[0][0], test_module.Conductor)
             shutdown_app.assert_called_once()
-            assert isinstance(shutdown_app.call_args[0][0], command.Conductor)
+            assert isinstance(shutdown_app.call_args[0][0], test_module.Conductor)
             run_loop.assert_called_once()
 
     async def test_run_loop(self):
@@ -46,9 +59,45 @@ class TestStart(AsyncTestCase):
         startup_call = startup()
         shutdown = async_mock.CoroutineMock()
         shutdown_call = shutdown()
-        with async_mock.patch.object(command, "asyncio", autospec=True) as mock_asyncio:
-            command.run_loop(startup_call, shutdown_call)
-            mock_asyncio.get_event_loop.return_value.add_signal_handler.assert_called_once()
+        with async_mock.patch.object(
+            test_module, "asyncio", autospec=True
+        ) as mock_asyncio:
+            test_module.run_loop(startup_call, shutdown_call)
+            mock_add = mock_asyncio.get_event_loop.return_value.add_signal_handler
+            mock_add.assert_called_once()
+            init_coro = mock_asyncio.ensure_future.call_args[0][0]
+            mock_asyncio.get_event_loop.return_value.run_forever.assert_called_once()
+            await init_coro
+            startup.assert_awaited_once()
+
+            done_calls = (
+                mock_asyncio.get_event_loop.return_value.add_signal_handler.call_args
+            )
+            done_calls[0][1]()  # exec partial
+            done_coro = mock_asyncio.ensure_future.call_args[0][0]
+            tasks = [
+                async_mock.MagicMock(),
+                async_mock.MagicMock(cancel=async_mock.MagicMock()),
+            ]
+            mock_asyncio.gather = async_mock.CoroutineMock()
+            mock_asyncio.Task.all_tasks.return_value = tasks
+            mock_asyncio.Task.current_task.return_value = tasks[0]
+            await done_coro
+            shutdown.assert_awaited_once()
+
+    async def test_run_loop_init_x(self):
+        startup = async_mock.CoroutineMock(side_effect=KeyError("the front fell off"))
+        startup_call = startup()
+        shutdown = async_mock.CoroutineMock()
+        shutdown_call = shutdown()
+        with async_mock.patch.object(
+            test_module, "asyncio", autospec=True
+        ) as mock_asyncio, async_mock.patch.object(
+            test_module, "LOGGER", autospec=True
+        ) as mock_logger:
+            test_module.run_loop(startup_call, shutdown_call)
+            mock_add = mock_asyncio.get_event_loop.return_value.add_signal_handler
+            mock_add.assert_called_once()
             init_coro = mock_asyncio.ensure_future.call_args[0][0]
             mock_asyncio.get_event_loop.return_value.run_forever.assert_called_once()
             await init_coro
@@ -65,3 +114,13 @@ class TestStart(AsyncTestCase):
             mock_asyncio.Task.current_task.return_value = task
             await done_coro
             shutdown.assert_awaited_once()
+            mock_logger.exception.assert_called_once()
+
+    def test_main(self):
+        with async_mock.patch.object(
+            test_module, "__name__", "__main__"
+        ) as mock_name, async_mock.patch.object(
+            test_module, "execute", async_mock.MagicMock()
+        ) as mock_execute:
+            test_module.main()
+            mock_execute.assert_called_once

--- a/aries_cloudagent/config/argparse.py
+++ b/aries_cloudagent/config/argparse.py
@@ -827,6 +827,31 @@ class TransportGroup(ArgumentGroup):
             option will require additional memory to store messages in the queue.",
         )
         parser.add_argument(
+            "--enable-kafka-queue",
+            action="store_true",
+            dest="enable_kafka_queue",
+            env_var="ACAPY_ENABLE_KAFKA_QUEUE",
+            help="Enable the inbound/outbound undelivered kafka queue. This"
+            "agent to send messages where the endpoint is not available to a kafka"
+            " service."
+        )
+        parser.add_argument(
+            "--kafka-producer-endpoint",
+            type=str,
+            nargs="+",
+            metavar="<endpoint>",
+            env_var="ACAPY_KAFKA_PRODUCER_ENDPOINT",
+            help=""
+        )
+        parser.add_argument(
+            "--kafka-consumer-endpoint",
+            type=str,
+            nargs="+",
+            metavar="<endpoint>",
+            env_var="ACAPY_KAFKA_CONSUMER_ENDPOINT",
+            help=""
+        )
+        parser.add_argument(
             "--max-outbound-retry",
             default=4,
             type=ByteSize(min_size=1),
@@ -848,7 +873,17 @@ class TransportGroup(ArgumentGroup):
         else:
             raise ArgsParseError("-ot/--outbound-transport is required")
         settings["transport.enable_undelivered_queue"] = args.enable_undelivered_queue
-
+        settings["transport.enable_kafka_queue"] = args.enable_kafka_queue
+        
+        if args.enable_kafka_queue:
+            if not args.kafka_producer_endpoint or not args.kafka_consumer_endpoint:
+                raise ArgsParseError(
+                    "Parameters --kafka-producer-endpoint and --kafka-consumer-endpoint must be provided"
+                    + " for kafka queue."
+                )
+        settings["transport.kafka_producer_endpoint"] = args.kafka_producer_endpoint
+        settings["transport.kafka_consumer_endpoint"] = args.kafka_consumer_endpoint
+        
         if args.label:
             settings["default_label"] = args.label
         if args.max_message_size:

--- a/aries_cloudagent/holder/base.py
+++ b/aries_cloudagent/holder/base.py
@@ -35,7 +35,9 @@ class BaseHolder(ABC, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def credential_revoked(self, credential_id: str, ledger: BaseLedger) -> bool:
+    async def credential_revoked(
+        self, credential_id: str, ledger: BaseLedger, fro: int = None, to: int = None
+    ) -> bool:
         """
         Check ledger for revocation status of credential by cred id.
 

--- a/aries_cloudagent/holder/indy.py
+++ b/aries_cloudagent/holder/indy.py
@@ -288,7 +288,9 @@ class IndyHolder(BaseHolder):
 
         return credential_json
 
-    async def credential_revoked(self, credential_id: str, ledger: BaseLedger) -> bool:
+    async def credential_revoked(
+        self, credential_id: str, ledger: BaseLedger, fro: int = None, to: int = None
+    ) -> bool:
         """
         Check ledger for revocation status of credential by cred id.
 
@@ -302,7 +304,7 @@ class IndyHolder(BaseHolder):
 
         if rev_reg_id:
             cred_rev_id = int(cred["cred_rev_id"])
-            (rev_reg_delta, _) = await ledger.get_revoc_reg_delta(rev_reg_id)
+            (rev_reg_delta, _) = await ledger.get_revoc_reg_delta(rev_reg_id, fro, to)
 
             return cred_rev_id in rev_reg_delta["value"].get("revoked", [])
         else:

--- a/aries_cloudagent/holder/routes.py
+++ b/aries_cloudagent/holder/routes.py
@@ -15,8 +15,8 @@ from ..messaging.valid import (
     INDY_REV_REG_ID,
     INDY_SCHEMA_ID,
     INDY_WQL,
-    NATURAL_NUM,
-    WHOLE_NUM,
+    NUM_STR_NATURAL,
+    NUM_STR_WHOLE,
     UUIDFour,
 )
 from ..wallet.error import WalletNotFoundError
@@ -57,17 +57,15 @@ class CredBriefListSchema(OpenAPISchema):
 class CredentialsListQueryStringSchema(OpenAPISchema):
     """Parameters and validators for query string in credentials list query."""
 
-    start = fields.Int(
+    start = fields.Str(
         description="Start index",
         required=False,
-        strict=True,
-        **WHOLE_NUM,
+        **NUM_STR_WHOLE,
     )
-    count = fields.Int(
+    count = fields.Str(
         description="Maximum number to retrieve",
         required=False,
-        strict=True,
-        **NATURAL_NUM,
+        **NUM_STR_NATURAL,
     )
     wql = fields.Str(
         description="(JSON) WQL query",
@@ -87,16 +85,16 @@ class CredIdMatchInfoSchema(OpenAPISchema):
 class CredRevokedQueryStringSchema(OpenAPISchema):
     """Path parameters and validators for request seeking cred revocation status."""
 
-    fro = fields.Int(
+    fro = fields.Str(
         data_key="from",
         description="Earliest epoch of revocation status interval of interest",
         required=False,
-        **WHOLE_NUM,
+        **NUM_STR_WHOLE,
     )
-    to = fields.Int(
+    to = fields.Str(
         description="Latest epoch of revocation status interval of interest",
         required=False,
-        **WHOLE_NUM,
+        **NUM_STR_WHOLE,
     )
 
 

--- a/aries_cloudagent/holder/routes.py
+++ b/aries_cloudagent/holder/routes.py
@@ -60,11 +60,13 @@ class CredentialsListQueryStringSchema(OpenAPISchema):
     start = fields.Int(
         description="Start index",
         required=False,
+        strict=True,
         **WHOLE_NUM,
     )
     count = fields.Int(
         description="Maximum number to retrieve",
         required=False,
+        strict=True,
         **NATURAL_NUM,
     )
     wql = fields.Str(

--- a/aries_cloudagent/holder/tests/test_routes.py
+++ b/aries_cloudagent/holder/tests/test_routes.py
@@ -61,8 +61,11 @@ class TestHolderRoutes(AsyncTestCase):
 
     async def test_credentials_revoked(self):
         request = async_mock.MagicMock(
-            app=self.app, match_info={"credential_id": "dummy"}
+            app=self.app,
+            match_info={"credential_id": "dummy"},
+            query={},
         )
+
         ledger = async_mock.create_autospec(BaseLedger)
 
         request.app["request_context"].inject = async_mock.CoroutineMock(
@@ -83,7 +86,9 @@ class TestHolderRoutes(AsyncTestCase):
 
     async def test_credentials_revoked_no_ledger(self):
         request = async_mock.MagicMock(
-            app=self.app, match_info={"credential_id": "dummy"}
+            app=self.app,
+            match_info={"credential_id": "dummy"},
+            query={},
         )
 
         request.app["request_context"].inject = async_mock.CoroutineMock(

--- a/aries_cloudagent/ledger/indy.py
+++ b/aries_cloudagent/ledger/indy.py
@@ -39,6 +39,8 @@ from .error import (
 )
 from .util import TAA_ACCEPTED_RECORD_TYPE
 
+LOGGER = logging.getLogger(__name__)
+
 GENESIS_TRANSACTION_PATH = tempfile.gettempdir()
 GENESIS_TRANSACTION_PATH = path.join(
     GENESIS_TRANSACTION_PATH, "indy_genesis_transactions.txt"
@@ -117,8 +119,6 @@ class IndyLedger(BaseLedger):
             cache: The cache instance to use
             cache_duration: The TTL for ledger cache entries
         """
-        self.logger = logging.getLogger(__name__)
-
         self.opened = False
         self.ref_count = 0
         self.ref_lock = asyncio.Lock()
@@ -155,16 +155,16 @@ class IndyLedger(BaseLedger):
 
         if await self.check_pool_config():
             if recreate:
-                self.logger.debug("Removing existing ledger config")
+                LOGGER.debug("Removing existing ledger config")
                 await indy.pool.delete_pool_ledger_config(self.pool_name)
             else:
                 raise LedgerConfigError(
                     "Ledger pool configuration already exists: %s", self.pool_name
                 )
 
-        self.logger.debug("Creating pool ledger config")
+        LOGGER.debug("Creating pool ledger config")
         with IndyErrorHandler(
-            "Exception when creating pool ledger config", LedgerConfigError
+            "Exception creating pool ledger config", LedgerConfigError
         ):
             await indy.pool.create_pool_ledger_config(self.pool_name, pool_config)
 
@@ -177,12 +177,12 @@ class IndyLedger(BaseLedger):
         """Open the pool ledger, creating it if necessary."""
         # We only support proto ver 2
         with IndyErrorHandler(
-            "Exception when setting ledger protocol version", LedgerConfigError
+            "Exception setting ledger protocol version", LedgerConfigError
         ):
             await indy.pool.set_protocol_version(2)
 
         with IndyErrorHandler(
-            f"Exception when opening pool ledger {self.pool_name}", LedgerConfigError
+            f"Exception opening pool ledger {self.pool_name}", LedgerConfigError
         ):
             self.pool_handle = await indy.pool.open_pool_ledger(self.pool_name, "{}")
         self.opened = True
@@ -205,11 +205,11 @@ class IndyLedger(BaseLedger):
                 break
 
             if exc:
-                self.logger.error("Exception when closing pool ledger")
+                LOGGER.error("Exception closing pool ledger")
                 self.ref_count += 1  # if we are here, we should have self.ref_lock
                 self.close_task = None
                 raise IndyErrorHandler.wrap_error(
-                    exc, "Exception when closing pool ledger", LedgerError
+                    exc, "Exception closing pool ledger", LedgerError
                 )
 
     async def _context_open(self):
@@ -218,7 +218,7 @@ class IndyLedger(BaseLedger):
             if self.close_task:
                 self.close_task.cancel()
             if not self.opened:
-                self.logger.debug("Opening the pool ledger")
+                LOGGER.debug("Opening the pool ledger")
                 await self.open()
             self.ref_count += 1
 
@@ -230,7 +230,7 @@ class IndyLedger(BaseLedger):
             await asyncio.sleep(timeout)
             async with self.ref_lock:
                 if not self.ref_count:
-                    self.logger.debug("Closing pool ledger after timeout")
+                    LOGGER.debug("Closing pool ledger after timeout")
                     await self.close()
 
         async with self.ref_lock:
@@ -360,7 +360,7 @@ class IndyLedger(BaseLedger):
             public_info.did, schema_name, schema_version, attribute_names
         )
         if schema_info:
-            self.logger.warning("Schema already exists on ledger. Returning details.")
+            LOGGER.warning("Schema already exists on ledger. Returning details.")
             schema_id, schema_def = schema_info
         else:
             if self.read_only:
@@ -379,9 +379,7 @@ class IndyLedger(BaseLedger):
                 raise LedgerError(err.message) from err
             schema_def = json.loads(schema_json)
 
-            with IndyErrorHandler(
-                "Exception when building schema request", LedgerError
-            ):
+            with IndyErrorHandler("Exception building schema request", LedgerError):
                 request_json = await indy.ledger.build_schema_request(
                     public_info.did, schema_json
                 )
@@ -398,17 +396,16 @@ class IndyLedger(BaseLedger):
                     ) from err
             except LedgerTransactionError as e:
                 # Identify possible duplicate schema errors on indy-node < 1.9 and > 1.9
-                if (
-                    "can have one and only one SCHEMA with name" in e.message
-                    or "UnauthorizedClientRequest" in e.message
-                ):
+                if "can have one and only one SCHEMA with name" in getattr(
+                    e, "message", ""
+                ) or "UnauthorizedClientRequest" in getattr(e, "message", ""):
                     # handle potential race condition if multiple agents are publishing
                     # the same schema simultaneously
                     schema_info = await self.check_existing_schema(
                         public_info.did, schema_name, schema_version, attribute_names
                     )
                     if schema_info:
-                        self.logger.warning(
+                        LOGGER.warning(
                             "Schema already exists on ledger. Returning details."
                             " Error: %s",
                             e,
@@ -486,7 +483,7 @@ class IndyLedger(BaseLedger):
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
 
-        with IndyErrorHandler("Exception when building schema request", LedgerError):
+        with IndyErrorHandler("Exception building schema request", LedgerError):
             request_json = await indy.ledger.build_get_schema_request(
                 public_did, schema_id
             )
@@ -497,7 +494,7 @@ class IndyLedger(BaseLedger):
             # schema not found
             return None
 
-        with IndyErrorHandler("Exception when parsing schema response", LedgerError):
+        with IndyErrorHandler("Exception parsing schema response", LedgerError):
             _, parsed_schema_json = await indy.ledger.parse_get_schema_response(
                 response_json
             )
@@ -587,7 +584,7 @@ class IndyLedger(BaseLedger):
                 credential_definition_id
             )
             if ledger_cred_def:
-                self.logger.warning(
+                LOGGER.warning(
                     "Credential definition %s already exists on ledger %s",
                     credential_definition_id,
                     self.pool_name,
@@ -639,9 +636,7 @@ class IndyLedger(BaseLedger):
                     "Error cannot write cred def when ledger is in read only mode"
                 )
 
-            with IndyErrorHandler(
-                "Exception when building cred def request", LedgerError
-            ):
+            with IndyErrorHandler("Exception building cred def request", LedgerError):
                 request_json = await indy.ledger.build_cred_def_request(
                     public_info.did, credential_definition_json
                 )
@@ -695,14 +690,14 @@ class IndyLedger(BaseLedger):
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
 
-        with IndyErrorHandler("Exception when building cred def request", LedgerError):
+        with IndyErrorHandler("Exception building cred def request", LedgerError):
             request_json = await indy.ledger.build_get_cred_def_request(
                 public_did, credential_definition_id
             )
 
         response_json = await self._submit(request_json, sign_did=public_info)
 
-        with IndyErrorHandler("Exception when parsing cred def response", LedgerError):
+        with IndyErrorHandler("Exception parsing cred def response", LedgerError):
             try:
                 (
                     _,
@@ -751,7 +746,7 @@ class IndyLedger(BaseLedger):
         nym = self.did_to_nym(did)
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
-        with IndyErrorHandler("Exception when building nym request", LedgerError):
+        with IndyErrorHandler("Exception building nym request", LedgerError):
             request_json = await indy.ledger.build_get_nym_request(public_did, nym)
         response_json = await self._submit(request_json, sign_did=public_info)
         data_json = (json.loads(response_json))["result"]["data"]
@@ -766,7 +761,7 @@ class IndyLedger(BaseLedger):
         nym = self.did_to_nym(did)
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
-        with IndyErrorHandler("Exception when building attribute request", LedgerError):
+        with IndyErrorHandler("Exception building attribute request", LedgerError):
             request_json = await indy.ledger.build_get_attrib_request(
                 public_did, nym, "endpoint", None, None
             )
@@ -795,7 +790,7 @@ class IndyLedger(BaseLedger):
         nym = self.did_to_nym(did)
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
-        with IndyErrorHandler("Exception when building attribute request", LedgerError):
+        with IndyErrorHandler("Exception building attribute request", LedgerError):
             request_json = await indy.ledger.build_get_attrib_request(
                 public_did, nym, "endpoint", None, None
             )
@@ -843,9 +838,7 @@ class IndyLedger(BaseLedger):
             else:
                 attr_json = json.dumps({"endpoint": {endpoint_type.indy: endpoint}})
 
-            with IndyErrorHandler(
-                "Exception when building attribute request", LedgerError
-            ):
+            with IndyErrorHandler("Exception building attribute request", LedgerError):
                 request_json = await indy.ledger.build_attrib_request(
                     nym, nym, None, attr_json, None
                 )
@@ -872,7 +865,7 @@ class IndyLedger(BaseLedger):
 
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
-        with IndyErrorHandler("Exception when building nym request", LedgerError):
+        with IndyErrorHandler("Exception building nym request", LedgerError):
             request_json = await indy.ledger.build_nym_request(
                 public_did, did, verkey, alias, role
             )
@@ -893,7 +886,7 @@ class IndyLedger(BaseLedger):
         public_info = await self.wallet.get_public_did()
         public_did = public_info.did if public_info else None
 
-        with IndyErrorHandler("Exception when building get-nym request", LedgerError):
+        with IndyErrorHandler("Exception building get-nym request", LedgerError):
             request_json = await indy.ledger.build_get_nym_request(public_did, did)
 
         response_json = await self._submit(request_json)
@@ -925,7 +918,7 @@ class IndyLedger(BaseLedger):
 
         # submit to ledger (retain role and alias)
         nym = self.did_to_nym(public_did)
-        with IndyErrorHandler("Exception when building nym request", LedgerError):
+        with IndyErrorHandler("Exception building nym request", LedgerError):
             request_json = await indy.ledger.build_get_nym_request(public_did, nym)
 
         response_json = await self._submit(request_json)
@@ -936,7 +929,7 @@ class IndyLedger(BaseLedger):
             )
         seq_no = data["seqNo"]
 
-        with IndyErrorHandler("Exception when building get-txn request", LedgerError):
+        with IndyErrorHandler("Exception building get-txn request", LedgerError):
             txn_req_json = await indy.ledger.build_get_txn_request(None, None, seq_no)
 
         txn_resp_json = await self._submit(txn_req_json)
@@ -1063,9 +1056,9 @@ class IndyLedger(BaseLedger):
                 found_def_json,
             ) = await indy.ledger.parse_get_revoc_reg_def_response(response_json)
         except IndyError as e:
-            logging.error(
-                f"get_revoc_reg_def failed with revoc_reg_id={revoc_reg_id}. "
-                f"{e.error_code}: {e.message}"
+            LOGGER.error(
+                f"get_revoc_reg_def failed with revoc_reg_id={revoc_reg_id} - "
+                f"{e.error_code}: {getattr(e, 'message', '[no message]')}"
             )
             raise e
 
@@ -1075,15 +1068,23 @@ class IndyLedger(BaseLedger):
     async def get_revoc_reg_entry(self, revoc_reg_id: str, timestamp: int):
         """Get revocation registry entry by revocation registry ID and timestamp."""
         public_info = await self.wallet.get_public_did()
-        fetch_req = await indy.ledger.build_get_revoc_reg_request(
-            public_info and public_info.did, revoc_reg_id, timestamp
-        )
-        response_json = await self._submit(fetch_req, sign_did=public_info)
-        (
-            found_id,
-            found_reg_json,
-            ledger_timestamp,
-        ) = await indy.ledger.parse_get_revoc_reg_response(response_json)
+        with IndyErrorHandler("Exception fetching rev reg entry", LedgerError):
+            try:
+                fetch_req = await indy.ledger.build_get_revoc_reg_request(
+                    public_info and public_info.did, revoc_reg_id, timestamp
+                )
+                response_json = await self._submit(fetch_req, sign_did=public_info)
+                (
+                    found_id,
+                    found_reg_json,
+                    ledger_timestamp,
+                ) = await indy.ledger.parse_get_revoc_reg_response(response_json)
+            except IndyError as e:
+                LOGGER.error(
+                    f"get_revoc_reg_entry failed with revoc_reg_id={revoc_reg_id} - "
+                    f"{e.error_code}: {getattr(e, 'message', '[no message]')}"
+                )
+                raise e
         assert found_id == revoc_reg_id
         return json.loads(found_reg_json), ledger_timestamp
 
@@ -1094,24 +1095,35 @@ class IndyLedger(BaseLedger):
         Look up a revocation registry delta by ID.
 
         :param revoc_reg_id revocation registry id
-        :param timestamp_from from time. a total number of seconds from Unix Epoch
-        :param timestamp_to to time. a total number of seconds from Unix Epoch
+        :param timestamp_from earliest EPOCH time of interest
+        :param timestamp_to latest EPOCH time of interest
 
         :returns delta response, delta timestamp
         """
         if timestamp_to is None:
             timestamp_to = int(time())
         public_info = await self.wallet.get_public_did()
-        fetch_req = await indy.ledger.build_get_revoc_reg_delta_request(
-            public_info and public_info.did, revoc_reg_id, timestamp_from, timestamp_to
-        )
+        with IndyErrorHandler("Exception building rev reg delta request", LedgerError):
+            fetch_req = await indy.ledger.build_get_revoc_reg_delta_request(
+                public_info and public_info.did,
+                revoc_reg_id,
+                timestamp_from,
+                timestamp_to,
+            )
         response_json = await self._submit(fetch_req, sign_did=public_info)
-        (
-            found_id,
-            found_delta_json,
-            delta_timestamp,
-        ) = await indy.ledger.parse_get_revoc_reg_delta_response(response_json)
-        assert found_id == revoc_reg_id
+        with IndyErrorHandler(
+            (
+                "Exception parsing rev reg delta response "
+                "(interval ends before rev reg creation?)"
+            ),
+            LedgerError,
+        ):
+            (
+                found_id,
+                found_delta_json,
+                delta_timestamp,
+            ) = await indy.ledger.parse_get_revoc_reg_delta_response(response_json)
+            assert found_id == revoc_reg_id
         return json.loads(found_delta_json), delta_timestamp
 
     async def send_revoc_reg_def(self, revoc_reg_def: dict, issuer_did: str = None):
@@ -1125,9 +1137,10 @@ class IndyLedger(BaseLedger):
             raise LedgerTransactionError(
                 "No issuer DID found for revocation registry definition"
             )
-        request_json = await indy.ledger.build_revoc_reg_def_request(
-            did_info.did, json.dumps(revoc_reg_def)
-        )
+        with IndyErrorHandler("Exception building rev reg def", LedgerError):
+            request_json = await indy.ledger.build_revoc_reg_def_request(
+                did_info.did, json.dumps(revoc_reg_def)
+            )
         await self._submit(request_json, True, True, did_info)
 
     async def send_revoc_reg_entry(
@@ -1146,7 +1159,8 @@ class IndyLedger(BaseLedger):
             raise LedgerTransactionError(
                 "No issuer DID found for revocation registry entry"
             )
-        request_json = await indy.ledger.build_revoc_reg_entry_request(
-            did_info.did, revoc_reg_id, revoc_def_type, json.dumps(revoc_reg_entry)
-        )
+        with IndyErrorHandler("Exception building rev reg entry", LedgerError):
+            request_json = await indy.ledger.build_revoc_reg_entry_request(
+                did_info.did, revoc_reg_id, revoc_def_type, json.dumps(revoc_reg_entry)
+            )
         await self._submit(request_json, True, True, did_info)

--- a/aries_cloudagent/ledger/routes.py
+++ b/aries_cloudagent/ledger/routes.py
@@ -6,7 +6,7 @@ from aiohttp_apispec import docs, querystring_schema, request_schema, response_s
 from marshmallow import fields, validate
 
 from ..messaging.models.openapi import OpenAPISchema
-from ..messaging.valid import ENDPOINT_TYPE, INDY_DID, INDY_RAW_PUBLIC_KEY
+from ..messaging.valid import ENDPOINT_TYPE, INDY_DID, INDY_RAW_PUBLIC_KEY, INT_EPOCH
 from ..storage.error import StorageError
 from ..wallet.error import WalletError
 
@@ -36,7 +36,7 @@ class TAAAcceptanceSchema(OpenAPISchema):
     """TAA acceptance record."""
 
     mechanism = fields.Str()
-    time = fields.Int()
+    time = fields.Int(strict=True, **INT_EPOCH)
 
 
 class TAAInfoSchema(OpenAPISchema):

--- a/aries_cloudagent/messaging/credential_definitions/routes.py
+++ b/aries_cloudagent/messaging/credential_definitions/routes.py
@@ -37,7 +37,10 @@ class CredentialDefinitionSendRequestSchema(OpenAPISchema):
         required=False, description="Revocation supported flag"
     )
     revocation_registry_size = fields.Int(
-        description="Revocation registry size", required=False, **INDY_REV_REG_SIZE
+        description="Revocation registry size",
+        required=False,
+        strict=True,
+        **INDY_REV_REG_SIZE,
     )
     tag = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/decorators/attach_decorator.py
+++ b/aries_cloudagent/messaging/decorators/attach_decorator.py
@@ -656,10 +656,11 @@ class AttachDecoratorSchema(BaseModelSchema):
     filename = fields.Str(
         description="File name", example="IMG1092348.png", required=False
     )
-    byte_count = fields.Integer(
+    byte_count = fields.Int(
         description="Byte count of data included by reference",
         example=1234,
         required=False,
+        strict=True,
     )
     lastmod_time = fields.Str(
         description="Hint regarding last modification datetime, in ISO-8601 format",

--- a/aries_cloudagent/messaging/decorators/tests/test_base.py
+++ b/aries_cloudagent/messaging/decorators/tests/test_base.py
@@ -35,7 +35,7 @@ class SampleDecoratorSchema(BaseModelSchema):
         model_class = SampleDecorator
         unknown = EXCLUDE
 
-    score = fields.Int(required=True)
+    score = fields.Int(required=True, strict=True)
 
 
 class TestBaseDecoratorSet(TestCase):

--- a/aries_cloudagent/messaging/decorators/thread_decorator.py
+++ b/aries_cloudagent/messaging/decorators/thread_decorator.py
@@ -131,17 +131,19 @@ class ThreadDecoratorSchema(BaseModelSchema):
         description="Parent thread identifier",
         example=UUIDFour.EXAMPLE,  # typically a UUID4 but not necessarily
     )
-    sender_order = fields.Integer(
+    sender_order = fields.Int(
         required=False,
         allow_none=True,
         description="Ordinal of message among all from current sender in thread",
         example=11,
+        strict=True,
     )
     received_orders = fields.Dict(
         keys=fields.Str(description="Sender key"),
-        values=fields.Integer(
+        values=fields.Int(
             description="Highest sender_order value for sender",
-            example="3",
+            example=3,
+            strict=True,
         ),
         required=False,
         allow_none=True,

--- a/aries_cloudagent/messaging/decorators/timing_decorator.py
+++ b/aries_cloudagent/messaging/decorators/timing_decorator.py
@@ -82,6 +82,7 @@ class TimingDecoratorSchema(BaseModelSchema):
         required=False,
         description="Number of milliseconds to delay processing",
         example=1000,
+        strict=True,
     )
     wait_until_time = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/decorators/trace_decorator.py
+++ b/aries_cloudagent/messaging/decorators/trace_decorator.py
@@ -277,6 +277,7 @@ class TraceReportSchema(BaseModelSchema):
         allow_none=True,
         description="Elapsed milliseconds processing time",
         example=27,
+        strict=True,
     )
     outcome = fields.Str(
         required=False,

--- a/aries_cloudagent/messaging/decorators/transport_decorator.py
+++ b/aries_cloudagent/messaging/decorators/transport_decorator.py
@@ -60,5 +60,8 @@ class TransportDecoratorSchema(BaseModelSchema):
         example=UUIDFour.EXAMPLE,
     )
     queued_message_count = fields.Int(
-        required=False, description="Number of queued messages", **WHOLE_NUM
+        required=False,
+        description="Number of queued messages",
+        strict=True,
+        **WHOLE_NUM,
     )

--- a/aries_cloudagent/messaging/schemas/routes.py
+++ b/aries_cloudagent/messaging/schemas/routes.py
@@ -71,7 +71,7 @@ class SchemaSchema(OpenAPISchema):
         description="Schema attribute names",
         data_key="attrNames",
     )
-    seqNo = fields.Int(description="Schema sequence number", **NATURAL_NUM)
+    seqNo = fields.Int(description="Schema sequence number", strict=True, **NATURAL_NUM)
 
 
 class SchemaGetResultsSchema(OpenAPISchema):

--- a/aries_cloudagent/messaging/tests/test_valid.py
+++ b/aries_cloudagent/messaging/tests/test_valid.py
@@ -38,15 +38,14 @@ from ..valid import (
 
 class TestValid(TestCase):
     def test_epoch(self):
-        non_epochs = [-9223372036854775809, 9223372036854775808]
+        non_epochs = [-1, 18446744073709551616]
         for non_epoch in non_epochs:
             with self.assertRaises(ValidationError):
                 INT_EPOCH["validate"](non_epoch)
 
         INT_EPOCH["validate"](0)
         INT_EPOCH["validate"](2147483647)
-        INT_EPOCH["validate"](-9223372036854775808)
-        INT_EPOCH["validate"](9223372036854775807)
+        INT_EPOCH["validate"](18446744073709551615)
 
     def test_whole(self):
         non_wholes = [-9223372036854775809, 2.3, "Hello", None]

--- a/aries_cloudagent/messaging/tests/test_valid.py
+++ b/aries_cloudagent/messaging/tests/test_valid.py
@@ -28,6 +28,8 @@ from ..valid import (
     INDY_WQL,
     INT_EPOCH,
     NATURAL_NUM,
+    NUM_STR_NATURAL,
+    NUM_STR_WHOLE,
     JWS_HEADER_KID,
     JWT,
     SHA256,
@@ -58,14 +60,33 @@ class TestValid(TestCase):
         WHOLE_NUM["validate"](12345678901234567890)
 
     def test_natural(self):
-        non_naturals = [-9223372036854775809, 2.3, "Hello", 0, None]
-        for non_natural in non_naturals:
+        non_naturals = [-9223372036854775809, 2.3, "Hello", None]
+        for non_naturals in non_naturals:
             with self.assertRaises(ValidationError):
-                NATURAL_NUM["validate"](non_natural)
+                NATURAL_NUM["validate"](non_naturals)
 
         NATURAL_NUM["validate"](1)
-        NATURAL_NUM["validate"](2)
         NATURAL_NUM["validate"](12345678901234567890)
+
+    def test_str_whole(self):
+        non_str_wholes = ["-9223372036854775809", "Hello", "5.5", "4+3"]
+        for non_str_whole in non_str_wholes:
+            with self.assertRaises(ValidationError):
+                NUM_STR_WHOLE["validate"](non_str_whole)
+
+        NUM_STR_WHOLE["validate"]("0")
+        NUM_STR_WHOLE["validate"]("1")
+        NUM_STR_WHOLE["validate"]("12345678901234567890")
+
+    def test_str_natural(self):
+        non_str_naturals = ["-9223372036854775809", "Hello", "0", "5.5"]
+        for non_str_natural in non_str_naturals:
+            with self.assertRaises(ValidationError):
+                NUM_STR_NATURAL["validate"](non_str_natural)
+
+        NUM_STR_NATURAL["validate"]("1")
+        NUM_STR_NATURAL["validate"]("2")
+        NUM_STR_NATURAL["validate"]("12345678901234567890")
 
     def test_indy_rev_reg_size(self):
         non_indy_rr_sizes = [-9223372036854775809, 2.3, "Hello", 0, 3, 32769, None]

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -25,9 +25,9 @@ class IntEpoch(Range):
     def __init__(self):
         """Initializer."""
 
-        super().__init__(  # use 64-bit for Aries RFC compatibility
-            min=-9223372036854775808,
-            max=9223372036854775807,
+        super().__init__(  # use u64 for indy-sdk compatibility
+            min=0,
+            max=18446744073709551615,
             error="Value {input} is not a valid integer epoch time",
         )
 

--- a/aries_cloudagent/messaging/valid.py
+++ b/aries_cloudagent/messaging/valid.py
@@ -50,6 +50,21 @@ class WholeNumber(Range):
         super().__call__(value)
 
 
+class NumericStrWhole(Regexp):
+    """Validate value against whole number numeric string."""
+
+    EXAMPLE = "0"
+    PATTERN = rf"^[0-9]*$"
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            NumericStrWhole.PATTERN,
+            error="Value {input} is not a non-negative numeric string",
+        )
+
+
 class NaturalNumber(Range):
     """Validate value as positive integer."""
 
@@ -66,6 +81,21 @@ class NaturalNumber(Range):
         if type(value) != int:
             raise ValidationError("Value {input} is not a valid natural number")
         super().__call__(value)
+
+
+class NumericStrNatural(Regexp):
+    """Validate value against natural number numeric string."""
+
+    EXAMPLE = "1"
+    PATTERN = rf"^[1-9][0-9]*$"
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            NumericStrNatural.PATTERN,
+            error="Value {input} is not a positive numeric string",
+        )
 
 
 class IndyRevRegSize(Range):
@@ -497,7 +527,12 @@ class EndpointType(OneOf):
 # Instances for marshmallow schema specification
 INT_EPOCH = {"validate": IntEpoch(), "example": IntEpoch.EXAMPLE}
 WHOLE_NUM = {"validate": WholeNumber(), "example": WholeNumber.EXAMPLE}
+NUM_STR_WHOLE = {"validate": NumericStrWhole(), "example": NumericStrWhole.EXAMPLE}
 NATURAL_NUM = {"validate": NaturalNumber(), "example": NaturalNumber.EXAMPLE}
+NUM_STR_NATURAL = {
+    "validate": NumericStrNatural(),
+    "example": NumericStrNatural.EXAMPLE,
+}
 INDY_REV_REG_SIZE = {"validate": IndyRevRegSize(), "example": IndyRevRegSize.EXAMPLE}
 JWS_HEADER_KID = {"validate": JWSHeaderKid(), "example": JWSHeaderKid.EXAMPLE}
 JWT = {"validate": JSONWebToken(), "example": JSONWebToken.EXAMPLE}

--- a/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
+++ b/aries_cloudagent/protocols/actionmenu/v1_0/routes.py
@@ -227,7 +227,7 @@ async def register(app: web.Application):
             web.post("/action-menu/{conn_id}/fetch", actionmenu_fetch),
             web.post("/action-menu/{conn_id}/perform", actionmenu_perform),
             web.post("/action-menu/{conn_id}/request", actionmenu_request),
-            web.post("/connections/{conn_id}/send-menu", actionmenu_send),
+            web.post("/action-menu/{conn_id}/send-menu", actionmenu_send),
         ]
     )
 

--- a/aries_cloudagent/protocols/connections/v1_0/routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/routes.py
@@ -53,6 +53,26 @@ class ReceiveInvitationRequestSchema(ConnectionInvitationSchema):
         """Bypass middleware field validation."""
 
 
+class InvitationConnectionTargetRequestSchema(OpenAPISchema):
+    """Request schema for invitation connection target."""
+
+    recipient_keys = fields.List(
+        fields.Str(description="Recipient public key", **INDY_RAW_PUBLIC_KEY),
+        required=False,
+        description="List of recipient keys",
+    )
+    service_endpoint = fields.Str(
+        required=False,
+        description="Connection endpoint",
+        example="http://192.168.56.102:8020",
+    )
+    routing_keys = fields.List(
+        fields.Str(description="Routing key", **INDY_RAW_PUBLIC_KEY),
+        required=False,
+        description="List of routing keys",
+    )
+
+
 class InvitationResultSchema(OpenAPISchema):
     """Result schema for a new connection invitation."""
 
@@ -301,6 +321,7 @@ async def connections_retrieve(request: web.BaseRequest):
     summary="Create a new connection invitation",
 )
 @querystring_schema(CreateInvitationQueryStringSchema())
+@request_schema(InvitationConnectionTargetRequestSchema())
 @response_schema(InvitationResultSchema(), 200)
 async def connections_create_invitation(request: web.BaseRequest):
     """
@@ -318,6 +339,10 @@ async def connections_create_invitation(request: web.BaseRequest):
     alias = request.query.get("alias")
     public = json.loads(request.query.get("public", "false"))
     multi_use = json.loads(request.query.get("multi_use", "false"))
+    body = await request.json()
+    recipient_keys = body.get("recipient_keys")
+    service_endpoint = body.get("service_endpoint")
+    routing_keys = body.get("routing_keys")
 
     if public and not context.settings.get("public_invites"):
         raise web.HTTPForbidden(
@@ -328,7 +353,13 @@ async def connections_create_invitation(request: web.BaseRequest):
     connection_mgr = ConnectionManager(context)
     try:
         (connection, invitation) = await connection_mgr.create_invitation(
-            auto_accept=auto_accept, public=public, multi_use=multi_use, alias=alias
+            auto_accept=auto_accept,
+            public=public,
+            multi_use=multi_use,
+            alias=alias,
+            recipient_keys=recipient_keys,
+            my_endpoint=service_endpoint,
+            routing_keys=routing_keys,
         )
 
         result = {

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_manager.py
@@ -196,6 +196,31 @@ class TestConnectionManager(AsyncTestCase, TestConfig):
 
         await self.manager.receive_request(requestB, receipt)
 
+    async def test_create_invitation_recipient_routing_endpoint(self):
+        wallet: BaseWallet = await self.context.inject(BaseWallet)
+        await wallet.create_local_did(
+            seed=self.test_seed, did=self.test_did, metadata=None
+        )
+        connect_record, connect_invite = await self.manager.create_invitation(
+            my_endpoint=self.test_endpoint,
+            recipient_keys=[self.test_verkey],
+            routing_keys=[self.test_verkey],
+        )
+
+        receipt = MessageReceipt(recipient_verkey=connect_record.invitation_key)
+
+        requestA = ConnectionRequest(
+            connection=ConnectionDetail(
+                did=self.test_target_did,
+                did_doc=self.make_did_doc(
+                    self.test_target_did, self.test_target_verkey
+                ),
+            ),
+            label="InviteRequestA",
+        )
+
+        await self.manager.receive_request(requestA, receipt)
+
     async def test_receive_invitation(self):
         (_, connect_invite) = await self.manager.create_invitation(
             my_endpoint="testendpoint"

--- a/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/connections/v1_0/tests/test_routes.py
@@ -162,6 +162,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",
@@ -204,6 +205,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",
@@ -228,6 +230,7 @@ class TestConnectionRoutes(AsyncTestCase):
         mock_req.app = {
             "request_context": context,
         }
+        mock_req.json = async_mock.CoroutineMock()
         mock_req.query = {
             "auto_accept": "true",
             "alias": "alias",

--- a/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+++ b/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
@@ -297,6 +297,7 @@ class RevokeQueryStringSchema(OpenAPISchema):
     cred_rev_id = fields.Int(
         description="Credential revocation identifier",
         required=True,
+        strict=True,
         **NATURAL_NUM,
     )
     publish = fields.Boolean(
@@ -660,6 +661,7 @@ async def _create_free_offer(
     cred_ex_record = V10CredentialExchange(
         connection_id=connection_id,
         initiator=V10CredentialExchange.INITIATOR_SELF,
+        role=V10CredentialExchange.ROLE_ISSUER,
         credential_definition_id=cred_def_id,
         credential_proposal_dict=credential_proposal_dict,
         auto_issue=auto_issue,

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -264,14 +264,6 @@ class PresentationManager:
 
         """
 
-        def nudge_interval(interval: dict):
-            """Coerce non-revocation interval to integer values."""
-            if isinstance(interval.get("from", 0), float):
-                interval["from"] = int(interval["from"] + 1)
-            if isinstance(interval.get("to", 0), float):
-                interval["to"] = int(interval["to"])
-            return interval
-
         # Get all credentials for this presentation
         holder: BaseHolder = await self.context.inject(BaseHolder)
         credentials = {}
@@ -342,7 +334,6 @@ class PresentationManager:
         non_revoc_interval.update(
             presentation_exchange_record.presentation_request.get("non_revoked") or {}
         )
-        nudge_interval(non_revoc_interval)
 
         revoc_reg_deltas = {}
         async with ledger:
@@ -353,8 +344,8 @@ class PresentationManager:
                 if "timestamp" in precis:
                     continue
                 rev_reg_id = credentials[credential_id]["rev_reg_id"]
-                referent_non_revoc_interval = nudge_interval(
-                    precis.get("non_revoked", non_revoc_interval)
+                referent_non_revoc_interval = precis.get(
+                    "non_revoked", non_revoc_interval
                 )
 
                 if referent_non_revoc_interval:

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -263,6 +263,15 @@ class PresentationManager:
             A tuple (updated presentation exchange record, presentation message)
 
         """
+
+        def nudge_interval(interval: dict):
+            """Coerce non-revocation interval to integer values."""
+            if isinstance(interval.get("from", 0), float):
+                interval["from"] = int(interval["from"] + 1)
+            if isinstance(interval.get("to", 0), float):
+                interval["to"] = int(interval["to"])
+            return interval
+
         # Get all credentials for this presentation
         holder: BaseHolder = await self.context.inject(BaseHolder)
         credentials = {}
@@ -333,6 +342,7 @@ class PresentationManager:
         non_revoc_interval.update(
             presentation_exchange_record.presentation_request.get("non_revoked") or {}
         )
+        nudge_interval(non_revoc_interval)
 
         revoc_reg_deltas = {}
         async with ledger:
@@ -343,8 +353,8 @@ class PresentationManager:
                 if "timestamp" in precis:
                     continue
                 rev_reg_id = credentials[credential_id]["rev_reg_id"]
-                referent_non_revoc_interval = precis.get(
-                    "non_revoked", non_revoc_interval
+                referent_non_revoc_interval = nudge_interval(
+                    precis.get("non_revoked", non_revoc_interval)
                 )
 
                 if referent_non_revoc_interval:

--- a/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/messages/inner/presentation_preview.py
@@ -87,7 +87,7 @@ class PresPredSpecSchema(BaseModelSchema):
         required=True,
         **INDY_PREDICATE,
     )
-    threshold = fields.Int(description="Threshold value", required=True)
+    threshold = fields.Int(description="Threshold value", required=True, strict=True)
 
 
 class PresAttrSpec(BaseModel):

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -176,9 +176,10 @@ class IndyProofReqNonRevokedSchema(OpenAPISchema):
             ValidationError: if data has neither from nor to
 
         """
-        if not (data.get("from") or data.get("to")):
+        if not (data.get("fro") or data.get("to")):
             raise ValidationError(
-                "Non-revocation interval must have at least one end", ("fro", "to")
+                "Non-revocation interval must have at least one end",
+                "(from, to)",
             )
 
 

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -156,11 +156,13 @@ class IndyProofReqNonRevokedSchema(OpenAPISchema):
         description="Earliest epoch of interest for non-revocation proof",
         required=False,
         data_key="from",
+        strict=True,
         **INT_EPOCH,
     )
     to = fields.Int(
         description="Latest epoch of interest for non-revocation proof",
         required=False,
+        strict=True,
         **INT_EPOCH,
     )
 
@@ -176,7 +178,7 @@ class IndyProofReqNonRevokedSchema(OpenAPISchema):
             ValidationError: if data has neither from nor to
 
         """
-        if not (data.get("fro") or data.get("to")):
+        if not data:
             raise ValidationError(
                 "Non-revocation interval must have at least one end",
                 "(from, to)",
@@ -255,7 +257,7 @@ class IndyProofReqPredSpecSchema(OpenAPISchema):
         required=True,
         **INDY_PREDICATE,
     )
-    p_value = fields.Integer(description="Threshold value", required=True)
+    p_value = fields.Int(description="Threshold value", required=True, strict=True)
     restrictions = fields.List(
         fields.Nested(IndyProofReqPredSpecRestrictionsSchema()),
         description="If present, credential must satisfy one of given restrictions",
@@ -333,6 +335,7 @@ class IndyRequestedCredsRequestedAttrSchema(OpenAPISchema):
     timestamp = fields.Int(
         description="Epoch timestamp of interest for non-revocation proof",
         required=False,
+        strict=True,
         **INT_EPOCH,
     )
 
@@ -350,6 +353,7 @@ class IndyRequestedCredsRequestedPredSchema(OpenAPISchema):
     timestamp = fields.Int(
         description="Epoch timestamp of interest for non-revocation proof",
         required=False,
+        strict=True,
         **INT_EPOCH,
     )
 
@@ -402,9 +406,17 @@ class CredentialsFetchQueryStringSchema(OpenAPISchema):
         required=False,
         example="1_name_uuid,2_score_uuid",
     )
-    start = fields.Int(description="Start index", required=False, **WHOLE_NUM)
+    start = fields.Int(
+        description="Start index",
+        required=False,
+        strict=True,
+        **WHOLE_NUM,
+    )
     count = fields.Int(
-        description="Maximum number to retrieve", required=False, **NATURAL_NUM
+        description="Maximum number to retrieve",
+        required=False,
+        strict=True,
+        **NATURAL_NUM,
     )
     extra_query = fields.Str(
         description="(JSON) object mapping referents to extra WQL queries",

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -28,10 +28,10 @@ from ....messaging.valid import (
     INDY_SCHEMA_ID,
     INDY_VERSION,
     INT_EPOCH,
-    NATURAL_NUM,
+    NUM_STR_NATURAL,
+    NUM_STR_WHOLE,
     UUIDFour,
     UUID4,
-    WHOLE_NUM,
 )
 from ....storage.error import StorageError, StorageNotFoundError
 from ....utils.tracing import trace_event, get_timer, AdminAPIMessageTracingSchema
@@ -406,17 +406,16 @@ class CredentialsFetchQueryStringSchema(OpenAPISchema):
         required=False,
         example="1_name_uuid,2_score_uuid",
     )
-    start = fields.Int(
+    start = fields.Str(
         description="Start index",
         required=False,
         strict=True,
-        **WHOLE_NUM,
+        **NUM_STR_WHOLE,
     )
-    count = fields.Int(
+    count = fields.Str(
         description="Maximum number to retrieve",
         required=False,
-        strict=True,
-        **NATURAL_NUM,
+        **NUM_STR_NATURAL,
     )
     extra_query = fields.Str(
         description="(JSON) object mapping referents to extra WQL queries",

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
@@ -315,6 +315,16 @@ class TestPresentationManager(AsyncTestCase):
             nonce=PROOF_REQ_NONCE,
             ledger=await self.context.inject(BaseLedger, required=False),
         )
+        indy_proof_req["non_revoked"] = {  # exercise nudge to int
+            "from": 1234567890.1,
+            "to": NOW + 0.1,
+        }
+        for uuid in indy_proof_req["requested_attributes"]:
+            indy_proof_req["requested_attributes"][uuid]["non_revoked"]["from"] -= 0.1
+            indy_proof_req["requested_attributes"][uuid]["non_revoked"]["to"] += 0.1
+        for uuid in indy_proof_req["requested_predicates"]:
+            indy_proof_req["requested_predicates"][uuid]["non_revoked"]["from"] -= 0.1
+            indy_proof_req["requested_predicates"][uuid]["non_revoked"]["to"] += 0.1
 
         exchange_in.presentation_request = indy_proof_req
         request = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_manager.py
@@ -315,16 +315,6 @@ class TestPresentationManager(AsyncTestCase):
             nonce=PROOF_REQ_NONCE,
             ledger=await self.context.inject(BaseLedger, required=False),
         )
-        indy_proof_req["non_revoked"] = {  # exercise nudge to int
-            "from": 1234567890.1,
-            "to": NOW + 0.1,
-        }
-        for uuid in indy_proof_req["requested_attributes"]:
-            indy_proof_req["requested_attributes"][uuid]["non_revoked"]["from"] -= 0.1
-            indy_proof_req["requested_attributes"][uuid]["non_revoked"]["to"] += 0.1
-        for uuid in indy_proof_req["requested_predicates"]:
-            indy_proof_req["requested_predicates"][uuid]["non_revoked"]["from"] -= 0.1
-            indy_proof_req["requested_predicates"][uuid]["non_revoked"]["to"] += 0.1
 
         exchange_in.presentation_request = indy_proof_req
         request = async_mock.MagicMock()

--- a/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/tests/test_routes.py
@@ -18,9 +18,9 @@ class TestProofRoutes(AsyncTestCase):
 
     async def test_validate_non_revoked(self):
         non_revo = test_module.IndyProofReqNonRevokedSchema()
-        non_revo.validate_fields({"from": 1234567890})
+        non_revo.validate_fields({"fro": 1234567890})
         non_revo.validate_fields({"to": 1234567890})
-        non_revo.validate_fields({"from": 1234567890, "to": 1234567890})
+        non_revo.validate_fields({"fro": 1234567890, "to": 1234567890})
         with self.assertRaises(test_module.ValidationError):
             non_revo.validate_fields({})
 

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginate.py
@@ -36,5 +36,5 @@ class PaginateSchema(BaseModelSchema):
         model_class = Paginate
         unknown = EXCLUDE
 
-    limit = fields.Int(required=False)
-    offset = fields.Int(required=False)
+    limit = fields.Int(required=False, strict=True)
+    offset = fields.Int(required=False, strict=True)

--- a/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
+++ b/aries_cloudagent/protocols/routing/v1_0/models/paginated.py
@@ -48,7 +48,7 @@ class PaginatedSchema(BaseModelSchema):
         model_class = Paginated
         unknown = EXCLUDE
 
-    start = fields.Int(required=False)
-    end = fields.Int(required=False)
-    limit = fields.Int(required=False)
-    total = fields.Int(required=False)
+    start = fields.Int(required=False, strict=True)
+    end = fields.Int(required=False, strict=True)
+    limit = fields.Int(required=False, strict=True)
+    total = fields.Int(required=False, strict=True)

--- a/aries_cloudagent/revocation/models/indy.py
+++ b/aries_cloudagent/revocation/models/indy.py
@@ -58,10 +58,12 @@ class NonRevocationIntervalSchema(BaseModelSchema):
         required=False,
         description="Earliest time of interest in non-revocation interval",
         data_key="from",
+        strict=True,
         **INT_EPOCH
     )
     to = fields.Int(
         required=False,
         description="Latest time of interest in non-revocation interval",
+        strict=True,
         **INT_EPOCH
     )

--- a/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
+++ b/aries_cloudagent/revocation/models/issuer_rev_reg_record.py
@@ -424,6 +424,7 @@ class IssuerRevRegRecordSchema(BaseRecordSchema):
     max_cred_num = fields.Int(
         required=False,
         description="Maximum number of credentials for revocation registry",
+        strict=True,
         example=1000,
     )
     revoc_def_type = fields.Str(

--- a/aries_cloudagent/revocation/routes.py
+++ b/aries_cloudagent/revocation/routes.py
@@ -60,7 +60,10 @@ class RevRegCreateRequestSchema(OpenAPISchema):
         description="Credential definition identifier", **INDY_CRED_DEF_ID
     )
     max_cred_num = fields.Int(
-        required=False, description="Revocation registry size", **INDY_REV_REG_SIZE
+        required=False,
+        description="Revocation registry size",
+        strict=True,
+        **INDY_REV_REG_SIZE,
     )
 
 
@@ -162,6 +165,7 @@ class RevRegIssuedResultSchema(OpenAPISchema):
 
     result = fields.Int(
         description="Number of credentials issued against revocation registry",
+        strict=True,
         **WHOLE_NUM,
     )
 

--- a/demo/AgentTracing.md
+++ b/demo/AgentTracing.md
@@ -95,4 +95,10 @@ DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo faber --tr
 DOCKER_NET=efk-stack_efk_net TRACE_TARGET_URL=fluentd:8088 ./run_demo alice --trace-http
 ```
 
+## Hooking into event messaging
 
+ACA-PY supports sending events to web hooks, which allows the demo agents to display them in the CLI. To also send them to another end point, use the `--webhook-url` option, which requires the `WEBHOOK_URL` environment variable. Configure an end point running on the docker host system, port *8888*, use the following:
+
+```bash
+WEBHOOK_URL=host.docker.internal:8888 ./run_demo faber --webhook-url
+```

--- a/demo/AliceGetsAPhone.md
+++ b/demo/AliceGetsAPhone.md
@@ -98,6 +98,8 @@ For revocation to function, we need another component running that is used to st
 
 If you are not running with revocation enabled you can skip this step.
 
+#### Running locally in a bash shell?
+
 Open a new bash shell, and in a project directory, run:
 
 ```bash
@@ -118,9 +120,17 @@ ngrok-tails-server_1  | t=2020-05-13T22:51:14+0000 lvl=info msg="started tunnel"
 
 Note the server name in the `url=https://c5789aa0.ngrok.io` parameter (`https://c5789aa0.ngrok.io`) - this is the external url for your tails server. Make sure you use the `https` url!
 
+#### Running in Play with Docker?
+
+Run the same steps on _PWD_ as you would run locally (see above).  Open a new shell (click on "ADD NEW INSTANCE") to run the tails server.
+
+Note that with _Play with Docker_ it can be challenging to capture the information you need from the log file as it scrolls by, you can try leaving off the `--events` option when you run the Faber agent to reduce the quantity of information logged to the screen.
+
 ### Run `faber` With Extra Parameters
 
-If you are running in a _local bash shell_, navigate to [The demo direcory](/demo) and run:
+#### Running locally in a bash shell?
+
+If you are running in a _local bash shell_, navigate to [The demo directory](/demo) and run:
 
 ```bash
 TAILS_NETWORK=docker_tails-server LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
@@ -128,15 +138,23 @@ TAILS_NETWORK=docker_tails-server LEDGER_URL=http://test.bcovrin.vonx.io ./run_d
 
 The `TAILS_NETWORK` parameter lets the demo script know how to connect to the tails server (which should be running in a separate shell on the same machine).
 
-If you are running in _Play with Docker_, navigate to [The demo direcory](/demo) and run:
+#### Running in Play with Docker?
+
+If you are running in _Play with Docker_, navigate to [The demo directory](/demo) and run:
 
 ```bash
-PUBLIC_TAILS_URL=https://def456.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
+PUBLIC_TAILS_URL=https://c4f7fbb85911.ngrok.io LEDGER_URL=http://test.bcovrin.vonx.io ./run_demo faber --revocation --events
 ```
 
 The `PUBLIC_TAILS_URL` parameter lets the demo script know how to connect to the tails server. This can be running in another PWD session, or even on your local machine - the ngrok endpoint is public and will map to the correct location.
 
-Note that you _must_ use the `https` url for the tails server endpoint.
+Use the ngrok url for the tails server that you noted earlier.
+
+*Note that you _must_ use the `https` url for the tails server endpoint.
+
+*Note - you may want to leave off the `--events` option when you run the Faber agent, if you are finding you are getting too much logging output.
+
+#### Waiting for the Faber agent to start ...
 
 The `Preparing agent image...` step on the first run takes a bit of time, so while we wait, let's look at the details of the commands. Running Faber is similar to the instructions in the [Aries OpenAPI Demo](./AriesOpenAPIDemo.md) "Play with Docker" section, except:
 

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -15,6 +15,7 @@ if ! [ -z "$TRACE_TARGET_URL" ]; then
 else
   TRACE_TARGET=log
 fi
+WEBHOOK_TARGET=""
 if [ -z "$DOCKER_NET" ]; then
   DOCKER_NET="bridge"
 fi
@@ -48,6 +49,10 @@ do
       TRACE_ENABLED=1
       TRACE_TARGET=http://${TRACE_TARGET_URL}/
       TRACE_TAG=acapy.events
+      continue
+    ;;
+    --webhook-url)
+      WEBHOOK_TARGET=http://${WEBHOOK_URL}
       continue
     ;;
     --debug-ptvsd)
@@ -104,9 +109,10 @@ Usage:
       --events - display on the terminal the webhook events from the ACA-Py agent.
       --timing - at the end of the run, display timing; relevant to the "performance" agent.
       --bg - run the agent in the background; for use when using OpenAPI/Swagger interface
-          --trace-log - log events to the standard log file
-          --trace-http - log events to an http endmoint specified in env var TRACE_TARGET_URL
+          --trace-log - log trace events to the standard log file
+          --trace-http - log trace events to an http endpoint specified in env var TRACE_TARGET_URL
           --self-attested - include a self-attested attribute in the proof request/response
+          --webhook-url - send events to an http endpoint specified in env var WEBHOOK_URL
       debug options: --debug-pycharm-agent-port <port>; --debug-pycharm-controller-port <port>
                     --debug-pycharm; --debug-ptvsd
 
@@ -207,6 +213,9 @@ if ! [ -z "$TRACE_TARGET" ]; then
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_TARGET=${TRACE_TARGET}"
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_TAG=${TRACE_TAG}"
   DOCKER_ENV="${DOCKER_ENV} -e TRACE_ENABLED=${TRACE_ENABLED}"
+fi
+if ! [ -z "$WEBHOOK_TARGET" ]; then
+  DOCKER_ENV="${DOCKER_ENV} -e WEBHOOK_TARGET=${WEBHOOK_TARGET}"
 fi
 # if $TAILS_NETWORK is specified it will override any previously specified $DOCKER_NET
 if ! [ -z "$TAILS_NETWORK" ]; then

--- a/demo/runners/support/agent.py
+++ b/demo/runners/support/agent.py
@@ -34,6 +34,8 @@ TRACE_TARGET = os.getenv("TRACE_TARGET")
 TRACE_TAG = os.getenv("TRACE_TAG")
 TRACE_ENABLED = os.getenv("TRACE_ENABLED")
 
+WEBHOOK_TARGET = os.getenv("WEBHOOK_TARGET")
+
 AGENT_ENDPOINT = os.getenv("AGENT_ENDPOINT")
 
 DEFAULT_POSTGRES = bool(os.getenv("POSTGRES"))
@@ -134,6 +136,7 @@ class DemoAgent:
         self.trace_enabled = TRACE_ENABLED
         self.trace_target = TRACE_TARGET
         self.trace_tag = TRACE_TAG
+        self.external_webhook_target = WEBHOOK_TARGET
 
         self.admin_url = f"http://{self.internal_host}:{admin_port}"
         if AGENT_ENDPOINT:
@@ -240,6 +243,8 @@ class DemoAgent:
             )
         if self.webhook_url:
             result.append(("--webhook-url", self.webhook_url))
+        if self.external_webhook_target:
+            result.append(("--webhook-url", self.external_webhook_target))
         if self.trace_enabled:
             result.extend(
                 [

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pyld==2.0.1
 py_multicodec==0.2.1
 pyyaml~=5.3.1
 ConfigArgParse~=1.2.3
+kafka-python~=2.0.2


### PR DESCRIPTION
Exploration of sending undeliverable messages to a Kafka service. When a message is not able to be delivered, a Kafka producer sends the message to a Kafka service for further processing. Kafka topics are `undeliverable_outbound` and `undeliverable_inbound`. Not tested. 
Next steps:
The inbound transport manager could be used to consume messages from a Kafka service. The topic the transport should consume is messages did's, with which the auth encrypted messages they know how to process? This would require a Kafka service that filters undeliverable messages to new topics. How to configure this consumer is not clear yet.